### PR TITLE
Add PartionContext.TestException to keep track of test exception in dispose(async)

### DIFF
--- a/src/Nullean.Xunit.Partitions/Sdk/IPartitionFixture.cs
+++ b/src/Nullean.Xunit.Partitions/Sdk/IPartitionFixture.cs
@@ -1,4 +1,9 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Nullean.Xunit.Partitions.Sdk;
 
@@ -15,4 +20,68 @@ public interface IPartitionFixture<out TLifetime> where TLifetime : IPartitionLi
 public interface IPartitionLifetime : IAsyncLifetime
 {
 	public int? MaxConcurrency { get; }
+}
+
+public static class PartitionContext
+{
+	private class Context
+	{
+		public Exception? Exception { get; internal set; }
+		public bool RanTest { get; internal set; }
+	}
+
+	private static readonly AsyncLocal<Context?> Local = new();
+
+	internal static void StopExceptionCapture()
+	{
+		if (Local.Value != null) Local.Value.RanTest = true;
+	}
+
+	internal static void StartExceptionCapture()
+	{
+		Local.Value ??= new Context();
+
+		AppDomain.CurrentDomain.FirstChanceException += (_, e) =>
+		{
+			if (Local.Value == null)
+				return;
+			if (Local.Value.RanTest)
+				return;
+
+			Local.Value.Exception = e.Exception;
+		};
+	}
+
+	// https://github.com/SimonCropp/XunitContext/blob/main/src/XunitContext/Context.cs#L39C3-L79C6
+	// Lifted from XunitContext, awesome library do check it out!
+
+	/// <summary>
+	/// The <see cref="Exception" /> for the current test if it failed.
+	/// </summary>
+	public static Exception? TestException
+	{
+		get
+		{
+			var e = Local.Value?.Exception;
+			switch (e)
+			{
+				case null: return null;
+				case XunitException: return e;
+			}
+
+			var outerTrace = new StackTrace(e, false);
+			var firstFrame = outerTrace.GetFrame(outerTrace.FrameCount - 1)!;
+			var firstMethod = firstFrame.GetMethod()!;
+
+			// firstMethod.DeclaringType can be null if the member was generated with reflection.
+			var root = firstMethod.DeclaringType?.DeclaringType;
+			if (root == null || root != typeof(ExceptionAggregator)) return null;
+
+			if (e is TargetInvocationException targetInvocationException)
+				return targetInvocationException.InnerException;
+
+			return e;
+
+		}
+	}
 }

--- a/tests/Nullean.Xunit.Partitions.Tests/SharedState1Class.cs
+++ b/tests/Nullean.Xunit.Partitions.Tests/SharedState1Class.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -51,4 +52,20 @@ public class NoStateClass
 {
 	[Fact]
 	public void SimpleTest() => 1.Should().Be(1);
+}
+
+public class FailingTests : IDisposable
+{
+	[Fact(Skip = "Enabling this would fail CI")]
+	public void OneIsNotZero() => 1.Should().Be(0);
+
+	public void Dispose() => PartitionContext.TestException.Should().NotBeNull();
+}
+
+public class SucceedingTests : IDisposable
+{
+	[Fact]
+	public void OneIsOne() => 1.Should().Be(1);
+
+	public void Dispose() => PartitionContext.TestException.Should().BeNull();
 }


### PR DESCRIPTION
This is lifted from `XunitContext`

https://github.com/SimonCropp/XunitContext/blob/main/src/XunitContext/Context.cs#L39C3-L79C6

Allows dispose routines to clean up based on whether a test succeeded or not. 

cc @SimonCropp
