### PR TITLE
Partition.InitializeAsync exceptions improvements.

### DIFF
--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -42,10 +42,7 @@ let private pristineCheck (arguments:ParseResults<Arguments>) =
     | _ -> failwithf "The checkout folder has pending changes, aborting"
 
 let private test (arguments:ParseResults<Arguments>) =
-    let junitOutput = Path.Combine(Paths.Output.FullName, "junit-{assembly}-{framework}-test-results.xml")
-    let loggerPathArgs = sprintf "LogFilePath=%s" junitOutput
-    let loggerArg = sprintf "--logger:\"junit;%s\"" loggerPathArgs
-    exec "dotnet" ["test"; "-c"; "RELEASE"; loggerArg; "--logger:pretty"] |> ignore
+    exec "dotnet" ["test"; "-c"; "RELEASE"; "--logger:GithubActions"; "--logger:pretty"] |> ignore
 
 let private generatePackages (arguments:ParseResults<Arguments>) =
     let output = Paths.RootRelative Paths.Output.FullName

--- a/src/Nullean.Xunit.Partitions/Sdk/IPartitionFixture.cs
+++ b/src/Nullean.Xunit.Partitions/Sdk/IPartitionFixture.cs
@@ -19,7 +19,13 @@ public interface IPartitionFixture<out TLifetime> where TLifetime : IPartitionLi
 /// </summary>
 public interface IPartitionLifetime : IAsyncLifetime
 {
-	public int? MaxConcurrency { get; }
+	int? MaxConcurrency { get; }
+
+	/// <summary>
+	/// Allows a partition to report output to tests if <see cref="IAsyncLifetime.InitializeAsync"/>
+	/// throws an exception.
+	/// </summary>
+	string FailureTestOutput();
 }
 
 public static class PartitionContext

--- a/src/Nullean.Xunit.Partitions/Sdk/NoopTest.cs
+++ b/src/Nullean.Xunit.Partitions/Sdk/NoopTest.cs
@@ -1,0 +1,10 @@
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Nullean.Xunit.Partitions.Sdk;
+
+internal class NoopTest(ITestCase xunitTestCase) : ITest
+{
+	public string DisplayName { get; } = xunitTestCase.DisplayName;
+	public ITestCase TestCase { get; } = xunitTestCase;
+}

--- a/src/Nullean.Xunit.Partitions/Sdk/NoopTest.cs
+++ b/src/Nullean.Xunit.Partitions/Sdk/NoopTest.cs
@@ -1,8 +1,10 @@
+using System;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Nullean.Xunit.Partitions.Sdk;
 
+[Serializable]
 internal class NoopTest(ITestCase xunitTestCase) : ITest
 {
 	public string DisplayName { get; } = xunitTestCase.DisplayName;

--- a/src/Nullean.Xunit.Partitions/Sdk/PartitionTestAssemblyRunner.cs
+++ b/src/Nullean.Xunit.Partitions/Sdk/PartitionTestAssemblyRunner.cs
@@ -273,7 +273,6 @@ public abstract class PartitionTestAssemblyRunner<TState> : XunitTestAssemblyRun
 	{
 		foreach (var t in testCases)
 		{
-
 			var test = new NoopTest(t);
 			ExecutionMessageSink.OnMessage(
 				new TestSkipped(test, skipText)
@@ -283,7 +282,7 @@ public abstract class PartitionTestAssemblyRunner<TState> : XunitTestAssemblyRun
 				});
 
 			ExecutionMessageSink.OnMessage(
-				new TestFinished(test, 2, "")
+				new TestFinished(test, 2, "Finished")
 				{
 					TestAssembly = t.TestMethod.TestClass.TestCollection.TestAssembly,
 					TestClass = t.TestMethod.TestClass

--- a/src/Nullean.Xunit.Partitions/Sdk/PartitionTestAssemblyRunner.cs
+++ b/src/Nullean.Xunit.Partitions/Sdk/PartitionTestAssemblyRunner.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -28,13 +29,26 @@ public class PartitionTestAssemblyRunner(
 		testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions, typeof(IPartitionFixture<>)
 	)
 {
-	protected override async Task UseStateAndRun(IPartitionLifetime partition, IMessageBus messageBus,
-		Func<int?, Task> runGroup)
+	protected override async Task UseStateAndRun(
+		IPartitionLifetime partition,
+		Func<int?, Task> runGroup,
+		Func<Exception, string, Task> failAll)
 	{
 		await using (partition)
 		{
-			await partition.InitializeAsync().ConfigureAwait(false);
-			await runGroup(partition.MaxConcurrency).ConfigureAwait(false);
+			var initialized = false;
+			try
+			{
+				await partition.InitializeAsync().ConfigureAwait(false);
+				initialized = true;
+			}
+			catch (Exception e)
+			{
+				DiagnosticMessageSink.OnMessage(new DiagnosticMessage(e.ToString()));
+				await failAll(e,  partition.FailureTestOutput());
+			}
+			if (initialized)
+				await runGroup(partition.MaxConcurrency).ConfigureAwait(false);
 		}
 	}
 }
@@ -118,7 +132,7 @@ public abstract class PartitionTestAssemblyRunner<TState> : XunitTestAssemblyRun
 		}
 	}
 
-	protected abstract Task UseStateAndRun(TState state, IMessageBus messageBus, Func<int?, Task> runGroup);
+	protected abstract Task UseStateAndRun(TState state, Func<int?, Task> runGroup, Func<Exception, string, Task> failAll);
 
 	protected override Task<RunSummary> RunTestCollectionAsync(
 		IMessageBus b,
@@ -169,12 +183,19 @@ public abstract class PartitionTestAssemblyRunner<TState> : XunitTestAssemblyRun
 				continue;
 			}
 
-			if (!_partitionFixtureInstances.TryGetValue(partitionType, out var state))
-				continue;
+			var state = CreatePartitionStateInstance(partitionType);
+			if (state == null)
+			{
+				var testClass = partitioning.Value.Select(g => g.Collection.DisplayName).FirstOrDefault();
+				throw new Exception($"{typeof(TState)} did not yield partition state for e.g: {testClass}");
+			}
 
 			var partitionName = state.GetType().Name;
 			if (PartitionRegex != null && !PartitionRegex.IsMatch(partitionName))
+			{
+				SkipAll(partitioning.Value, $"Unmatched: '{PartitionRegex}' for partition: '{partitionName}'");
 				continue;
+			}
 
 			var skipReasons = partitioning.Value.SelectMany(g => g.TestCases.Select(t => t.SkipReason)).ToList();
 			var allSkipped = skipReasons.All(r => !string.IsNullOrWhiteSpace(r));
@@ -186,11 +207,11 @@ public abstract class PartitionTestAssemblyRunner<TState> : XunitTestAssemblyRun
 
 			ClusterTotals.Add(partitionName, Stopwatch.StartNew());
 
-			await UseStateAndRun(state, messageBus, async (concurrency) =>
+			await UseStateAndRun(state, async (concurrency) =>
 			{
 				await RunPartitionGroupConcurrently(partitioning.Value, concurrency, messageBus, ctx)
 					.ConfigureAwait(false);
-			}).ConfigureAwait(false);
+			}, async (e, f) => await FailAll(partitioning.Value, e, f, ctx)).ConfigureAwait(false);
 
 			ClusterTotals[partitionName].Stop();
 		}
@@ -221,7 +242,10 @@ public abstract class PartitionTestAssemblyRunner<TState> : XunitTestAssemblyRun
 		var test = g.Collection.DisplayName.Replace("Test collection for", string.Empty).Trim();
 
 		if (TestRegex != null && !TestRegex.IsMatch(test))
+		{
+			SkipAllXunit(g.TestCases.ToList(), $"Unmatched: '{TestRegex}', test class: '{test}'" );
 			return;
+		}
 
 		try
 		{
@@ -238,6 +262,69 @@ public abstract class PartitionTestAssemblyRunner<TState> : XunitTestAssemblyRun
 			// TODO: What should happen here?
 		}
 	}
+
+	private void SkipAll(IEnumerable<PartitionTests> source, string skipText)
+	{
+		var testCases = source.SelectMany(t => t.TestCases).ToList();
+		SkipAllXunit(testCases, skipText);
+	}
+
+	private void SkipAllXunit(List<IXunitTestCase> testCases, string skipText)
+	{
+		foreach (var t in testCases)
+		{
+
+			var test = new NoopTest(t);
+			ExecutionMessageSink.OnMessage(
+				new TestSkipped(test, skipText)
+				{
+					TestAssembly = t.TestMethod.TestClass.TestCollection.TestAssembly,
+					TestClass = t.TestMethod.TestClass
+				});
+
+			ExecutionMessageSink.OnMessage(
+				new TestFinished(test, 2, "")
+				{
+					TestAssembly = t.TestMethod.TestClass.TestCollection.TestAssembly,
+					TestClass = t.TestMethod.TestClass
+				});
+		}
+
+		Summaries.Add(new RunSummary { Skipped = testCases.Count });
+	}
+
+	private async Task FailAll(IEnumerable<PartitionTests> source, Exception e, string failureText, CancellationTokenSource ctx)
+	{
+		var testCases = source.SelectMany(t => t.TestCases).ToList();
+		foreach (var t in testCases)
+		{
+			var test = new NoopTest(t);
+
+			ExecutionMessageSink.OnMessage(
+				new TestOutput(test, failureText)
+				{
+					TestAssembly = t.TestMethod.TestClass.TestCollection.TestAssembly,
+					TestClass = t.TestMethod.TestClass
+				});
+			ExecutionMessageSink.OnMessage(
+				new TestFailed(test, 2, e.Message, e)
+				{
+					TestAssembly = t.TestMethod.TestClass.TestCollection.TestAssembly,
+					TestClass = t.TestMethod.TestClass
+				});
+
+			ExecutionMessageSink.OnMessage(
+				new TestFinished(test, 2, "")
+				{
+					TestAssembly = t.TestMethod.TestClass.TestCollection.TestAssembly,
+					TestClass = t.TestMethod.TestClass
+				});
+		}
+		Summaries.Add(new RunSummary { Failed = testCases.Count });
+		await Task.CompletedTask;
+
+	}
+
 
 	private TState? CreatePartitionStateInstance(Type partitionType)
 	{

--- a/src/Nullean.Xunit.Partitions/Sdk/PartitionTestFrameworkDiscoverer.cs
+++ b/src/Nullean.Xunit.Partitions/Sdk/PartitionTestFrameworkDiscoverer.cs
@@ -39,13 +39,7 @@ public class PartitionTestFrameworkDiscoverer<TOptions> : XunitTestFrameworkDisc
 		return base.FindTestsForType(testClass, includeSourceInformation, messageBus, discoveryOptions);
 	}
 
-	protected override bool IsValidTestClass(ITypeInfo type)
-	{
-		if (PartitionRegex == null) return base.IsValidTestClass(type);
-
-		var partitionFixtureType = PartitionTestAssemblyRunner.GetPartitionFixtureType(type, _fixtureOpenGeneric);
-		return partitionFixtureType == null
-			? base.IsValidTestClass(type)
-			: PartitionRegex.IsMatch(partitionFixtureType.Name);
-	}
+	// leaving this in as a reminder it exists
+	// ReSharper disable once RedundantOverriddenMember
+	protected override bool IsValidTestClass(ITypeInfo type) => base.IsValidTestClass(type);
 }

--- a/src/Nullean.Xunit.Partitions/Sdk/PartitionTestFrameworkDiscoverer.cs
+++ b/src/Nullean.Xunit.Partitions/Sdk/PartitionTestFrameworkDiscoverer.cs
@@ -22,6 +22,7 @@ public class PartitionTestFrameworkDiscoverer<TOptions> : XunitTestFrameworkDisc
 		Type fixtureOpenGeneric
 		) : base(assemblyInfo, sourceProvider, diagnosticMessageSink)
 	{
+
 		_fixtureOpenGeneric = fixtureOpenGeneric;
 		var a = Assembly.Load(new AssemblyName(assemblyInfo.Name));
 		Options = PartitionOptionsAttribute.GetOptions<TOptions>(a);

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,7 +2,10 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
   <ItemGroup>
-    <PackageReference Include="JunitXml.TestLogger" Version="2.1.15" PrivateAssets="All" />
     <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.4.0" PrivateAssets="All" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/tests/Nullean.Xunit.Partitions.Tests/BadStateTests.cs
+++ b/tests/Nullean.Xunit.Partitions.Tests/BadStateTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nullean.Xunit.Partitions.Sdk;
+using Xunit;
+
+namespace Nullean.Xunit.Partitions.Tests;
+
+public class InitializeThrowsState : IPartitionLifetime
+{
+	public readonly bool Initialized = false;
+	public Task InitializeAsync() => throw new Exception("BOOM!");
+	//public Task InitializeAsync() => Task.CompletedTask;
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	public int? MaxConcurrency => null;
+
+	public string FailureTestOutput() => "This class always fails to run InitializeAsync";
+}
+
+public class BadStateTests(InitializeThrowsState longLivedObject) : IPartitionFixture<InitializeThrowsState>
+{
+	[Fact]
+	public void StaticInitializedShouldNotIncrease() => longLivedObject.Initialized.Should().BeFalse();
+
+	[Fact]
+	public void DisposeShouldNotHaveHappened() => longLivedObject.Initialized.Should().BeFalse();
+}

--- a/tests/Nullean.Xunit.Partitions.Tests/Setup.cs
+++ b/tests/Nullean.Xunit.Partitions.Tests/Setup.cs
@@ -13,7 +13,7 @@ public class MyPartitioningOptions : PartitionOptions
 {
 	public MyPartitioningOptions()
 	{
-		PartitionFilterRegex = "LongLivedObject";
+		PartitionFilterRegex = "^(?!InitializeThrowsState$).*";
 		TestFilterRegex = null;
 	}
 }

--- a/tests/Nullean.Xunit.Partitions.Tests/SharedState1Class.cs
+++ b/tests/Nullean.Xunit.Partitions.Tests/SharedState1Class.cs
@@ -28,6 +28,7 @@ public class LongLivedObject : IPartitionLifetime
 	}
 
 	public int? MaxConcurrency => null;
+	public string FailureTestOutput() => "";
 }
 
 public class SharedState1Class(LongLivedObject longLivedObject) : IPartitionFixture<LongLivedObject>


### PR DESCRIPTION
If a partition initializes with an exception we now fail all the tests that would have run fast.
These tests will all fail with the exception of IPartionLifetime.InitializeAsync.

Prior to this change these tests would not run at all and the exception would be printed to console.

Okay for CI purposes but in IDE's you want to see the tests fail properly too.

IPartition can now also provide failure text to failed tests so debugging becomes easier in IDE's too.

Lastly the filters now mark tests as skipped rather than invalid. This ensures the tests will always be displayed
and reported.
