### PR TITLE
Add xUnit v3 partition test framework (Nullean.Xunit.Partitions.v3)

### DIFF
--- a/nullean-xunit-partitions.slnx
+++ b/nullean-xunit-partitions.slnx
@@ -13,9 +13,11 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Nullean.Xunit.Partitions/Nullean.Xunit.Partitions.csproj" />
+    <Project Path="src/Nullean.Xunit.Partitions.v3/Nullean.Xunit.Partitions.v3.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <File Path="tests/Directory.Build.props" />
     <Project Path="tests/Nullean.Xunit.Partitions.Tests/Nullean.Xunit.Partitions.Tests.csproj" />
+    <Project Path="tests/Nullean.Xunit.Partitions.v3.Tests/Nullean.Xunit.Partitions.v3.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/Nullean.Xunit.Partitions.v3/Extensions/ForEachAsyncExtensions.cs
+++ b/src/Nullean.Xunit.Partitions.v3/Extensions/ForEachAsyncExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nullean.Xunit.Partitions.v3.Extensions;
+
+internal static class ForEachAsyncExtensions
+{
+	internal static Task ForEachAsync<T>(this IEnumerable<T> source, int dop, Func<T, Task> body) =>
+		Task.WhenAll(
+			from partition in Partitioner.Create(source).GetPartitions(dop)
+			select Task.Run(async delegate
+			{
+				using (partition)
+					while (partition.MoveNext())
+						await body(partition.Current).ConfigureAwait(false);
+			}));
+}

--- a/src/Nullean.Xunit.Partitions.v3/Nullean.Xunit.Partitions.v3.csproj
+++ b/src/Nullean.Xunit.Partitions.v3/Nullean.Xunit.Partitions.v3.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>false</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IsTestProject>false</IsTestProject>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\build\keys\keypair.snk</AssemblyOriginatorKeyFile>
+
+    <PackageIcon>nuget-icon.png</PackageIcon>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/nullean/xunit-partitions</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/nullean/xunit-partitions</PackageProjectUrl>
+    <PackageReleaseNotes>https://github.com/nullean/xunit-partitions/releases</PackageReleaseNotes>
+
+    <PackageId>Nullean.Xunit.Partitions.v3</PackageId>
+    <Title>Nullean.Xunit.Partitions.v3 - xUnit v3 test runner for tests that need to share state</Title>
+    <Description>xUnit v3 partitions for when you need to share long running state between tests</Description>
+
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="README.md" />
+    <Content Include="..\..\nuget-icon.png" Pack="true" PackagePath="nuget-icon.png" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
+    <PackageReference Update="MinVer" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Nullean.Xunit.Partitions.v3/PartitionOptions.cs
+++ b/src/Nullean.Xunit.Partitions.v3/PartitionOptions.cs
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Xunit.Sdk;
+
+namespace Nullean.Xunit.Partitions.v3;
+
+/// <summary> Control how execution of the partitioning test pipeline </summary>
+public class PartitionOptions
+{
+	/// <summary> A positive regular expression to filter tests, ONLY matches will run</summary>
+	public string? TestFilterRegex { get; set; }
+
+	/// <summary> A positive regular expression to filter partitions, ONLY matches will run</summary>
+	public string? PartitionFilterRegex { get; set; }
+
+	// ReSharper disable UnusedParameter.Global
+	/// <summary> Called when the tests have finished running successfully </summary>
+	/// <param name="partitionTimings">Per cluster timings of the total test time, including starting Elasticsearch</param>
+	/// <param name="failedPartitionTests">All collection of failed cluster, failed tests tuples</param>
+	public virtual void OnTestsFinished(
+		Dictionary<string, Stopwatch> partitionTimings,
+		ConcurrentBag<Tuple<string, string>> failedPartitionTests)
+	{
+	}
+	// ReSharper restore UnusedParameter.Global
+
+	/// <summary>
+	/// Called before tests run. An ideal place to perform actions such as writing information to
+	/// <see cref="Console" />.
+	/// </summary>
+	public virtual void OnBeforeTestsRun() { }
+
+	/// <summary> Expert option allows custom test runners to receive more options </summary>
+	public virtual void SetOptions(ITestFrameworkDiscoveryOptions discoveryOptions)
+	{
+		discoveryOptions.SetValue(nameof(PartitionFilterRegex), PartitionFilterRegex);
+		discoveryOptions.SetValue(nameof(TestFilterRegex), TestFilterRegex);
+	}
+
+	/// <summary> Expert option allows custom test runners to receive more options </summary>
+	public virtual void SetOptions(ITestFrameworkExecutionOptions executionOptions)
+	{
+		executionOptions.SetValue(nameof(PartitionFilterRegex), PartitionFilterRegex);
+		executionOptions.SetValue(nameof(TestFilterRegex), TestFilterRegex);
+	}
+}

--- a/src/Nullean.Xunit.Partitions.v3/PartitionOptionsAttribute.cs
+++ b/src/Nullean.Xunit.Partitions.v3/PartitionOptionsAttribute.cs
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Nullean.Xunit.Partitions.v3;
+
+/// <summary>
+///     An assembly attribute that specifies the <see cref="PartitionOptions" />
+///     for Xunit tests within the assembly.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public class PartitionOptionsAttribute : Attribute
+{
+	private readonly Type _type;
+
+	/// <summary>
+	///     Creates a new instance of <see cref="PartitionOptionsAttribute" />
+	/// </summary>
+	/// <param name="type">
+	///     A type deriving from <see cref="PartitionOptions" /> that specifies the run options
+	/// </param>
+	public PartitionOptionsAttribute(Type type) => _type = type;
+
+	private TOptions GetOptions<TOptions>() where TOptions : PartitionOptions, new()
+	{
+		 var options = Activator.CreateInstance(_type) as TOptions;
+		 return options ?? new TOptions();
+	}
+
+	public static TOptions GetOptions<TOptions>(Assembly assembly) where TOptions : PartitionOptions, new()
+	{
+		var options = assembly
+			.GetCustomAttributes()
+			.OfType<PartitionOptionsAttribute?>()
+			.FirstOrDefault()
+			?.GetOptions<TOptions>()
+			?? new TOptions();
+
+		return options;
+	}
+}

--- a/src/Nullean.Xunit.Partitions.v3/PartitionTestFramework.cs
+++ b/src/Nullean.Xunit.Partitions.v3/PartitionTestFramework.cs
@@ -1,0 +1,34 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Reflection;
+using Nullean.Xunit.Partitions.v3.Sdk;
+using Xunit.Sdk;
+using Xunit.v3;
+
+namespace Nullean.Xunit.Partitions.v3;
+
+// ReSharper disable once UnusedType.Global
+/// <summary>
+/// An <see cref="XunitTestFramework"/> implementation that introduces the concept of partitions.
+/// <para>A <see cref="IPartitionFixture{TLifetime}"/> allows tests to inject a long lived object.</para>
+/// <para>Only a single partition will run at a time in contrast with collection fixtures</para>
+/// <para>However unlike collection fixtures, <see cref="IPartitionFixture{TLifetime}"/>
+/// does not mark a concurrency barrier, tests belonging to a single partition still run concurrently</para>
+/// <para>Each <see cref="IPartitionFixture{TLifetime}"/> can declare its own desired concurrency through
+/// <see cref="IPartitionLifetime.MaxConcurrency"/> </para>
+/// </summary>
+// ReSharper disable once ClassNeverInstantiated.Global
+public class PartitionTestFramework : PartitionTestFramework<PartitionOptions>;
+
+public class PartitionTestFramework<TOptions> : XunitTestFramework
+	where TOptions : PartitionOptions, new()
+{
+	protected override ITestFrameworkExecutor CreateExecutor(Assembly assembly)
+	{
+		var options = PartitionOptionsAttribute.GetOptions<TOptions>(assembly);
+		var testAssembly = new XunitTestAssembly(assembly);
+		return new PartitionTestFrameworkExecutor<TOptions>(options, testAssembly);
+	}
+}

--- a/src/Nullean.Xunit.Partitions.v3/README.md
+++ b/src/Nullean.Xunit.Partitions.v3/README.md
@@ -1,0 +1,142 @@
+# Nullean.Xunit.Partitions.v3
+
+<a href="https://www.nuget.org/packages/Nullean.Xunit.Partitions.v3/"><img src="https://img.shields.io/nuget/v/Nullean.Xunit.Partitions.v3?color=blue&style=plastic" /></a>
+
+An xUnit v3 `TestFramework` implementation that introduces the concept of **partitions** for sharing long-lived state across tests.
+
+> This is the **xUnit v3** version. For xUnit v2, use [`Nullean.Xunit.Partitions`](https://www.nuget.org/packages/Nullean.Xunit.Partitions/).
+
+## Why partitions?
+
+`IPartitionFixture<TLifetime>` lets tests inject a long-lived object (Docker container, database, Playwright browser, etc.) that is shared across multiple test classes.
+
+- **Only one partition runs at a time** &mdash; partitions execute serially, so expensive resources don't compete.
+- **Tests within a partition run concurrently** &mdash; unlike `ICollectionFixture<T>`, partitions are not a concurrency barrier.
+- **Just-in-time lifecycle** &mdash; `InitializeAsync` is called right before a partition's tests run, and `DisposeAsync` right after. This is more efficient than assembly fixtures which bootstrap at startup and dispose at shutdown.
+- **Per-partition concurrency control** &mdash; each `IPartitionLifetime` can declare its own `MaxConcurrency`.
+
+If you want to share a few (0&ndash;20) long-running objects over thousands of tests, this library is for you.
+If you have many test collections with only a few tests each, xUnit's native collection fixtures may be a better fit.
+
+## Setup
+
+xUnit v3 test projects are executables. Your `.csproj` should look like:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="Nullean.Xunit.Partitions.v3" Version="*" />
+  </ItemGroup>
+</Project>
+```
+
+Register the test framework with an assembly-level attribute:
+
+```csharp
+using Nullean.Xunit.Partitions.v3;
+using Xunit;
+
+[assembly: TestFramework(typeof(PartitionTestFramework))]
+```
+
+## Usage
+
+Define a partition lifetime &mdash; the shared state that will be initialized once and injected into all test classes that request it:
+
+```csharp
+public class LongLivedObject : IPartitionLifetime
+{
+    private static long _initialized;
+    private static long _disposed;
+
+    public long Initialized => _initialized;
+    public long Disposed => _disposed;
+
+    public ValueTask InitializeAsync()
+    {
+        Interlocked.Increment(ref _initialized);
+        return default;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Interlocked.Increment(ref _disposed);
+        return default;
+    }
+
+    public int? MaxConcurrency => null;
+    public string FailureTestOutput() => "";
+}
+```
+
+Test classes receive the shared instance via constructor injection by implementing `IPartitionFixture<T>`:
+
+```csharp
+public class SharedState1Class(LongLivedObject state) : IPartitionFixture<LongLivedObject>
+{
+    [Fact]
+    public void InitializedOnce() => state.Initialized.Should().Be(1);
+
+    [Fact]
+    public void NotDisposedYet() => state.Disposed.Should().Be(0);
+}
+
+public class SharedState2Class(LongLivedObject state) : IPartitionFixture<LongLivedObject>
+{
+    [Fact]
+    public void InitializedOnce() => state.Initialized.Should().Be(1);
+
+    [Fact]
+    public void NotDisposedYet() => state.Disposed.Should().Be(0);
+}
+```
+
+Both classes share a single `LongLivedObject` instance. Their tests run concurrently within the partition. `DisposeAsync` runs only after all tests in the partition complete.
+
+Test classes without `IPartitionFixture<T>` are grouped into an implicit "no partition" group and run concurrently with default concurrency.
+
+## Providing options
+
+Control partition and test filtering with a custom options class:
+
+```csharp
+using Nullean.Xunit.Partitions.v3;
+using Xunit;
+
+[assembly: TestFramework(typeof(PartitionTestFramework))]
+[assembly: PartitionOptions(typeof(MyOptions))]
+
+public class MyOptions : PartitionOptions
+{
+    public MyOptions()
+    {
+        // Only run partitions whose type name matches this regex
+        PartitionFilterRegex = "LongLivedObject";
+        // Only run test classes whose name matches this regex (null = all)
+        TestFilterRegex = null;
+    }
+}
+```
+
+You can also override `OnBeforeTestsRun()` and `OnTestsFinished(...)` for custom logging or reporting.
+
+## Migrating from v2
+
+| v2 | v3 |
+|---|---|
+| `[assembly: TestFramework(Partition.TestFramework, Partition.Assembly)]` | `[assembly: TestFramework(typeof(PartitionTestFramework))]` |
+| `Task InitializeAsync()` / `Task DisposeAsync()` | `ValueTask InitializeAsync()` / `ValueTask DisposeAsync()` |
+| `PartitionContext.TestException` | `TestContext.Current.TestState` (xUnit v3 built-in) |
+| `return Task.CompletedTask;` | `return default;` |
+| `Nullean.Xunit.Partitions` namespace | `Nullean.Xunit.Partitions.v3` namespace |
+| Test project is a class library | Test project is an executable (`<OutputType>Exe</OutputType>`) |
+| Requires `xunit.runner.visualstudio` + `Microsoft.NET.Test.Sdk` | Self-hosting &mdash; no runner packages needed |
+
+## License
+
+MIT

--- a/src/Nullean.Xunit.Partitions.v3/Sdk/IPartitionFixture.cs
+++ b/src/Nullean.Xunit.Partitions.v3/Sdk/IPartitionFixture.cs
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Xunit;
+
+namespace Nullean.Xunit.Partitions.v3.Sdk;
+
+// marker interface
+// ReSharper disable once UnusedTypeParameter
+public interface IPartitionFixture<out TLifetime> where TLifetime : IPartitionLifetime;
+
+/// <summary>
+/// The object that provides long running state to tests.
+/// <para>Avoid work in constructors, state has to be initialized early to satisfy XUnit constructor injection</para>
+/// <para>Utilize <see cref="IAsyncLifetime.InitializeAsync"/> to bootstrap over constructors</para>
+/// <para>Utilize <see cref="IAsyncLifetime.DisposeAsync"/> to wind down state</para>
+/// <para>In v3, use <c>TestContext.Current.TestState</c> to access test exception state
+/// instead of the v2 <c>PartitionContext.TestException</c></para>
+/// </summary>
+public interface IPartitionLifetime : IAsyncLifetime
+{
+	int? MaxConcurrency { get; }
+
+	/// <summary>
+	/// Allows a partition to report output to tests if <see cref="IAsyncLifetime.InitializeAsync"/>
+	/// throws an exception.
+	/// </summary>
+	string FailureTestOutput();
+}

--- a/src/Nullean.Xunit.Partitions.v3/Sdk/PartitionFixtureMappingManager.cs
+++ b/src/Nullean.Xunit.Partitions.v3/Sdk/PartitionFixtureMappingManager.cs
@@ -1,0 +1,19 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Xunit.v3;
+
+namespace Nullean.Xunit.Partitions.v3.Sdk;
+
+/// <summary>
+/// A <see cref="FixtureMappingManager"/> that pre-populates with partition fixture instances
+/// using the protected constructor that accepts cached fixture values.
+/// </summary>
+internal class PartitionFixtureMappingManager : FixtureMappingManager
+{
+	public PartitionFixtureMappingManager(object[] cachedFixtureValues)
+		: base("Partition", cachedFixtureValues)
+	{
+	}
+}

--- a/src/Nullean.Xunit.Partitions.v3/Sdk/PartitionTestAssemblyRunner.cs
+++ b/src/Nullean.Xunit.Partitions.v3/Sdk/PartitionTestAssemblyRunner.cs
@@ -1,0 +1,334 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Nullean.Xunit.Partitions.v3.Extensions;
+using Xunit.Sdk;
+using Xunit.v3;
+
+namespace Nullean.Xunit.Partitions.v3.Sdk;
+
+internal record NullableKeyType
+{
+	public Type? Type { get; set; }
+}
+
+public class PartitionTests
+{
+	public Type? FixtureLifetimeType { get; set; }
+	public IXunitTestCollection Collection { get; set; } = null!;
+	public List<IXunitTestCase> TestCases { get; set; } = null!;
+}
+
+public class PartitionTestAssemblyRunner : XunitTestAssemblyRunner
+{
+	private readonly Dictionary<Type, IPartitionLifetime> _partitionFixtureInstances = new();
+
+	//threading guess
+	private static int DefaultConcurrency => Environment.ProcessorCount * 4;
+
+	public ConcurrentBag<Tuple<string, string>> FailedCollections { get; } = new();
+
+	public Dictionary<string, Stopwatch> ClusterTotals { get; } = new();
+
+	// Set by the executor before calling Run
+	internal Regex? PartitionRegex { get; set; }
+	internal Regex? TestRegex { get; set; }
+
+	private Dictionary<NullableKeyType, IEnumerable<PartitionTests>>? _partitions;
+
+	private Dictionary<NullableKeyType, IEnumerable<PartitionTests>> BuildPartitions(
+		XunitTestAssemblyRunnerContext ctxt)
+	{
+		var orderedCollections = OrderTestCollections(ctxt);
+
+		var cases =
+			from testCollection in orderedCollections
+			let classes = testCollection.Item2
+				.Select(tc => tc.TestClass?.Class)
+				.Where(t => t != null)
+				.Distinct()
+			let partition = classes.Select(c => GetPartitionFixtureType(c!)).FirstOrDefault(p => p != null)
+			let testcase = new PartitionTests
+			{
+				Collection = testCollection.Item1,
+				TestCases = testCollection.Item2,
+				FixtureLifetimeType = partition
+			}
+			select testcase;
+
+		return cases
+			.GroupBy(c => c.FixtureLifetimeType)
+			.OrderBy(g => g.Count())
+			.ToDictionary(k => new NullableKeyType { Type = k.Key }, v => v.Select(g => g));
+	}
+
+	protected override async ValueTask<RunSummary> RunTestCollections(
+		XunitTestAssemblyRunnerContext ctxt,
+		Exception? exception)
+	{
+		_partitions = BuildPartitions(ctxt);
+
+		// Pre-instantiate partition fixture types for constructor injection
+		foreach (var partition in _partitions)
+		{
+			var partitionType = partition.Key.Type;
+			if (partitionType == null)
+				continue;
+
+			var state = CreatePartitionStateInstance(partitionType, ctxt);
+			if (state == null) continue;
+
+			_partitionFixtureInstances[partitionType] = state;
+		}
+
+		return await RunAllTests(ctxt).ConfigureAwait(false);
+	}
+
+	private async ValueTask<RunSummary> RunAllTests(XunitTestAssemblyRunnerContext ctxt)
+	{
+		var totalSummary = new RunSummary();
+
+		foreach (var partitioning in _partitions!)
+		{
+			var partitionType = partitioning.Key.Type;
+			if (partitionType == null)
+			{
+				var summary = await RunPartitionGroupConcurrently(partitioning.Value, DefaultConcurrency, ctxt).ConfigureAwait(false);
+				totalSummary.Aggregate(summary);
+				continue;
+			}
+
+			var state = CreatePartitionStateInstance(partitionType, ctxt);
+			if (state == null)
+			{
+				var testClass = partitioning.Value.Select(g => g.Collection.TestCollectionDisplayName).FirstOrDefault();
+				throw new Exception($"{typeof(IPartitionLifetime)} did not yield partition state for e.g: {testClass}");
+			}
+
+			var partitionName = state.GetType().Name;
+			if (PartitionRegex != null && !PartitionRegex.IsMatch(partitionName))
+			{
+				var skipSummary = SkipAll(ctxt, partitioning.Value, $"Unmatched: '{PartitionRegex}' for partition: '{partitionName}'");
+				totalSummary.Aggregate(skipSummary);
+				continue;
+			}
+
+			var skipReasons = partitioning.Value.SelectMany(g => g.TestCases.Select(t => t.SkipReason)).ToList();
+			var allSkipped = skipReasons.All(r => !string.IsNullOrWhiteSpace(r));
+			if (allSkipped)
+			{
+				var s = new RunSummary { Total = skipReasons.Count, Skipped = skipReasons.Count };
+				totalSummary.Aggregate(s);
+				continue;
+			}
+
+			ClusterTotals.Add(partitionName, Stopwatch.StartNew());
+
+			var partitionSummary = new RunSummary();
+			await UseStateAndRun(state, ctxt, async concurrency =>
+			{
+				var s = await RunPartitionGroupConcurrently(partitioning.Value, concurrency, ctxt)
+					.ConfigureAwait(false);
+				partitionSummary.Aggregate(s);
+			}, async (e, f) =>
+			{
+				var s = await FailAll(ctxt, partitioning.Value, e, f);
+				partitionSummary.Aggregate(s);
+			}).ConfigureAwait(false);
+			totalSummary.Aggregate(partitionSummary);
+
+			// Track failures for OnTestsFinished callback
+			if (partitionSummary.Failed > 0)
+			{
+				foreach (var g in partitioning.Value)
+				{
+					var test = g.Collection.TestCollectionDisplayName.Replace("Test collection for", string.Empty).Trim();
+					FailedCollections.Add(Tuple.Create(partitionName, test));
+				}
+			}
+
+			ClusterTotals[partitionName].Stop();
+		}
+
+		return totalSummary;
+	}
+
+	private async ValueTask UseStateAndRun(
+		IPartitionLifetime partition,
+		XunitTestAssemblyRunnerContext ctxt,
+		Func<int?, Task> runGroup,
+		Func<Exception, string, Task> failAll)
+	{
+		var initialized = false;
+		try
+		{
+			await partition.InitializeAsync().ConfigureAwait(false);
+			initialized = true;
+		}
+		catch (Exception e)
+		{
+			ctxt.MessageBus.QueueMessage(new DiagnosticMessage(e.ToString()));
+			await failAll(e, partition.FailureTestOutput());
+		}
+
+		if (initialized)
+			await runGroup(partition.MaxConcurrency).ConfigureAwait(false);
+
+		await partition.DisposeAsync().ConfigureAwait(false);
+	}
+
+	protected override async ValueTask<RunSummary> RunTestCollection(
+		XunitTestAssemblyRunnerContext ctxt,
+		IXunitTestCollection testCollection,
+		IReadOnlyCollection<IXunitTestCase> testCases)
+	{
+		// Collect all fixture instances: assembly fixtures + partition fixtures
+		var allFixtures = new List<object>();
+		foreach (var type in ctxt.TestAssembly.AssemblyFixtureTypes)
+		{
+			var fixture = await ctxt.AssemblyFixtureMappings.GetFixture(type);
+			if (fixture != null)
+				allFixtures.Add(fixture);
+		}
+		foreach (var kv in _partitionFixtureInstances)
+			allFixtures.Add(kv.Value);
+
+		// Create a combined fixture manager with all fixtures pre-populated
+		var combinedManager = new PartitionFixtureMappingManager(allFixtures.ToArray());
+
+		return await XunitTestCollectionRunner.Instance.Run(
+			testCollection,
+			testCases,
+			ctxt.ExplicitOption,
+			ctxt.MessageBus,
+			ctxt.AssemblyTestCaseOrderer ?? DefaultTestCaseOrderer.Instance,
+			ctxt.Aggregator,
+			ctxt.CancellationTokenSource,
+			combinedManager
+		).ConfigureAwait(false);
+	}
+
+	private async Task<RunSummary> RunPartitionGroupConcurrently(
+		IEnumerable<PartitionTests> source, int? concurrency, XunitTestAssemblyRunnerContext ctxt
+	)
+	{
+		var summaries = new ConcurrentBag<RunSummary>();
+
+		await source
+			.ForEachAsync(Math.Max(concurrency ?? 0, DefaultConcurrency),
+				async g =>
+				{
+					var summary = await ExecutePartitionGrouping(ctxt, g).ConfigureAwait(false);
+					summaries.Add(summary);
+				}
+			)
+			.ConfigureAwait(false);
+
+		var result = new RunSummary();
+		foreach (var s in summaries)
+			result.Aggregate(s);
+		return result;
+	}
+
+	private async Task<RunSummary> ExecutePartitionGrouping(
+		XunitTestAssemblyRunnerContext ctxt,
+		PartitionTests g
+	)
+	{
+		var test = g.Collection.TestCollectionDisplayName.Replace("Test collection for", string.Empty).Trim();
+
+		if (TestRegex != null && !TestRegex.IsMatch(test))
+		{
+			var cases = g.TestCases.Cast<ITestCase>().ToList();
+			XunitRunnerHelper.SkipTestCases(
+				ctxt.MessageBus, ctxt.CancellationTokenSource, cases,
+				$"Unmatched: '{TestRegex}', test class: '{test}'",
+				sendTestCollectionMessages: true,
+				sendTestClassMessages: true,
+				sendTestMethodMessages: true,
+				sendTestCaseMessages: true,
+				sendTestMessages: true
+			);
+			return new RunSummary { Total = cases.Count, Skipped = cases.Count };
+		}
+
+		try
+		{
+			var summary = await RunTestCollection(ctxt, g.Collection, g.TestCases).ConfigureAwait(false);
+			if (summary.Failed > 0)
+			{
+				var type = g.FixtureLifetimeType;
+				var partitionName = type?.Name ?? "UNKNOWN";
+				FailedCollections.Add(Tuple.Create(partitionName, test));
+			}
+			return summary;
+		}
+		catch (TaskCanceledException)
+		{
+			return new RunSummary();
+		}
+	}
+
+	private RunSummary SkipAll(XunitTestAssemblyRunnerContext ctxt, IEnumerable<PartitionTests> source, string skipText)
+	{
+		var testCases = source.SelectMany(t => t.TestCases).Cast<ITestCase>().ToList();
+		// Send skip messages for console display
+		XunitRunnerHelper.SkipTestCases(
+			ctxt.MessageBus, ctxt.CancellationTokenSource, testCases, skipText,
+			sendTestCollectionMessages: true,
+			sendTestClassMessages: true,
+			sendTestMethodMessages: true,
+			sendTestCaseMessages: true,
+			sendTestMessages: true
+		);
+		// Return our own summary — XunitRunnerHelper may count skips as failures
+		// when FailSkips is enabled, so we manage our own count
+		return new RunSummary { Total = testCases.Count, Skipped = testCases.Count };
+	}
+
+	private Task<RunSummary> FailAll(
+		XunitTestAssemblyRunnerContext ctxt,
+		IEnumerable<PartitionTests> source,
+		Exception e,
+		string failureText)
+	{
+		var testCases = source.SelectMany(t => t.TestCases).Cast<ITestCase>().ToList();
+		var summary = XunitRunnerHelper.FailTestCases(
+			ctxt.MessageBus, ctxt.CancellationTokenSource, testCases, e,
+			sendTestCollectionMessages: false,
+			sendTestClassMessages: false,
+			sendTestMethodMessages: false,
+			sendTestCaseMessages: true,
+			sendTestMessages: true
+		);
+		return Task.FromResult(summary);
+	}
+
+	private IPartitionLifetime? CreatePartitionStateInstance(Type partitionType, XunitTestAssemblyRunnerContext ctxt)
+	{
+		if (_partitionFixtureInstances.TryGetValue(partitionType, out var partition)) return partition;
+		ctxt.Aggregator.Run(() =>
+		{
+			var o = Activator.CreateInstance(partitionType);
+			partition = o as IPartitionLifetime;
+		});
+		if (partition != null)
+			_partitionFixtureInstances[partitionType] = partition;
+		return partition;
+	}
+
+	public static Type? GetPartitionFixtureType(Type testClass) =>
+		testClass.GetInterfaces()
+			.Where(i => i.IsGenericType)
+			.Where(t => t.GetGenericTypeDefinition() == typeof(IPartitionFixture<>))
+			.SelectMany(t => t.GetGenericArguments(), (_, a) => a)
+			.FirstOrDefault();
+}

--- a/src/Nullean.Xunit.Partitions.v3/Sdk/PartitionTestFrameworkExecutor.cs
+++ b/src/Nullean.Xunit.Partitions.v3/Sdk/PartitionTestFrameworkExecutor.cs
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Sdk;
+using Xunit.v3;
+
+namespace Nullean.Xunit.Partitions.v3.Sdk;
+
+internal class PartitionTestFrameworkExecutor<TOptions>(
+	TOptions options,
+	IXunitTestAssembly testAssembly
+)
+	: XunitTestFrameworkExecutor(testAssembly)
+	where TOptions : PartitionOptions, new()
+{
+	private TOptions Options { get; } = options;
+
+	public override async ValueTask RunTestCases(
+		IReadOnlyCollection<IXunitTestCase> testCases,
+		IMessageSink executionMessageSink,
+		ITestFrameworkExecutionOptions executionOptions,
+		CancellationToken cancellationToken)
+	{
+		Options.SetOptions(executionOptions);
+		try
+		{
+			Options.OnBeforeTestsRun();
+			var runner = new PartitionTestAssemblyRunner();
+
+			// Set partition filter options directly on the runner
+			if (!string.IsNullOrEmpty(Options.PartitionFilterRegex))
+				runner.PartitionRegex = new Regex(Options.PartitionFilterRegex);
+			if (!string.IsNullOrEmpty(Options.TestFilterRegex))
+				runner.TestRegex = new Regex(Options.TestFilterRegex);
+
+			await runner.Run(
+				TestAssembly,
+				testCases,
+				executionMessageSink,
+				executionOptions,
+				cancellationToken
+			).ConfigureAwait(false);
+			Options.OnTestsFinished(runner.ClusterTotals, runner.FailedCollections);
+		}
+		catch (Exception e)
+		{
+			executionMessageSink.OnMessage(ErrorMessage.FromException(e));
+			throw;
+		}
+	}
+}

--- a/tests/Nullean.Xunit.Partitions.v3.Tests/BadStateTests.cs
+++ b/tests/Nullean.Xunit.Partitions.v3.Tests/BadStateTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nullean.Xunit.Partitions.v3.Sdk;
+using Xunit;
+
+namespace Nullean.Xunit.Partitions.v3.Tests;
+
+public class InitializeThrowsState : IPartitionLifetime
+{
+	public readonly bool Initialized = false;
+	public ValueTask InitializeAsync() => throw new Exception("BOOM!");
+
+	public ValueTask DisposeAsync() => default;
+
+	public int? MaxConcurrency => null;
+
+	public string FailureTestOutput() => "This class always fails to run InitializeAsync";
+}
+
+public class BadStateTests(InitializeThrowsState longLivedObject) : IPartitionFixture<InitializeThrowsState>
+{
+	[Fact]
+	public void StaticInitializedShouldNotIncrease() => longLivedObject.Initialized.Should().BeFalse();
+
+	[Fact]
+	public void DisposeShouldNotHaveHappened() => longLivedObject.Initialized.Should().BeFalse();
+}

--- a/tests/Nullean.Xunit.Partitions.v3.Tests/Nullean.Xunit.Partitions.v3.Tests.csproj
+++ b/tests/Nullean.Xunit.Partitions.v3.Tests/Nullean.Xunit.Partitions.v3.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <PackageId>Nullean.Xunit.Partitions.v3.Tests</PackageId>
+    <NoWarn>$(NoWarn);xUnit1041</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Nullean.Xunit.Partitions.v3\Nullean.Xunit.Partitions.v3.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="MinVer" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/tests/Nullean.Xunit.Partitions.v3.Tests/Setup.cs
+++ b/tests/Nullean.Xunit.Partitions.v3.Tests/Setup.cs
@@ -1,0 +1,19 @@
+using Nullean.Xunit.Partitions.v3;
+using Nullean.Xunit.Partitions.v3.Tests;
+using Xunit;
+
+[assembly: TestFramework(typeof(PartitionTestFramework))]
+//optional only needed if you want to specify execution options to PartitionTestFramework
+[assembly: PartitionOptions(typeof(MyPartitioningOptions))]
+
+namespace Nullean.Xunit.Partitions.v3.Tests;
+
+/// <summary> Allows us to control the xunit partitioning test pipeline </summary>
+public class MyPartitioningOptions : PartitionOptions
+{
+	public MyPartitioningOptions()
+	{
+		PartitionFilterRegex = "^(?!InitializeThrowsState$).*";
+		TestFilterRegex = null;
+	}
+}

--- a/tests/Nullean.Xunit.Partitions.v3.Tests/SharedState1Class.cs
+++ b/tests/Nullean.Xunit.Partitions.v3.Tests/SharedState1Class.cs
@@ -1,0 +1,61 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nullean.Xunit.Partitions.v3.Sdk;
+using Xunit;
+
+namespace Nullean.Xunit.Partitions.v3.Tests;
+
+public class LongLivedObject : IPartitionLifetime
+{
+	private static long _initialized;
+	private static long _disposed;
+
+	public long Initialized => _initialized;
+	public long Disposed => _disposed;
+
+	public ValueTask InitializeAsync()
+	{
+		Interlocked.Increment(ref _initialized);
+		return default;
+	}
+
+	public ValueTask DisposeAsync()
+	{
+		Interlocked.Increment(ref _disposed);
+		return default;
+	}
+
+	public int? MaxConcurrency => null;
+	public string FailureTestOutput() => "";
+}
+
+public class SharedState1Class(LongLivedObject longLivedObject) : IPartitionFixture<LongLivedObject>
+{
+	[Fact]
+	public void StaticInitializedShouldNotIncrease() => longLivedObject.Initialized.Should().Be(1);
+
+	[Fact]
+	public void DisposeShouldNotHaveHappened() => longLivedObject.Disposed.Should().Be(0);
+}
+
+public class SharedState2Class(LongLivedObject longLivedObject) : IPartitionFixture<LongLivedObject>
+{
+	[Fact]
+	public void StaticInitializedShouldNotIncrease() => longLivedObject.Initialized.Should().Be(1);
+
+	[Fact]
+	public void DisposeShouldNotHaveHappened() => longLivedObject.Disposed.Should().Be(0);
+}
+
+public class NoStateClass
+{
+	[Fact]
+	public void SimpleTest() => 1.Should().Be(1);
+}
+
+public class SucceedingTests
+{
+	[Fact]
+	public void OneIsOne() => 1.Should().Be(1);
+}


### PR DESCRIPTION
xUnit v3 rewrote its extensibility layer — different runner architecture,
ValueTask-based lifecycles, self-hosting test executables — so the existing
v2 partition library cannot be used with v3 test projects.

This adds a new `Nullean.Xunit.Partitions.v3` NuGet package that brings
partition-based test execution to xUnit v3. Users who need to share
expensive long-lived state (Docker containers, databases, Playwright
browsers) across many test classes can now do so on v3 with the same
serial-partitions / concurrent-within-partition model:

  - Implement `IPartitionLifetime` with `ValueTask InitializeAsync()` /
    `ValueTask DisposeAsync()` for your shared resource
  - Mark test classes with `IPartitionFixture<TLifetime>` to receive the
    shared instance via constructor injection
  - Register with `[assembly: TestFramework(typeof(PartitionTestFramework))]`

Key differences from the v2 package:
  - `IAsyncLifetime` now uses `ValueTask` (xUnit v3 change)
  - `PartitionContext.TestException` removed — use v3's built-in
    `TestContext.Current.TestState` instead
  - Test projects are executables, no runner packages needed
  - Type-based framework registration instead of string constants

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
